### PR TITLE
Adds additional aggregation types

### DIFF
--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -15,6 +15,7 @@ defmodule Snap.Aggregation do
   def new(response) do
     %__MODULE__{
       buckets: response["buckets"],
+      interval: response["interval"],
       doc_count_error_upper_bound: response["doc_count_error_upper_bound"],
       sum_other_doc_count: response["sum_other_doc_count"],
       value: response["value"],
@@ -24,6 +25,7 @@ defmodule Snap.Aggregation do
 
   @type t :: %__MODULE__{
           buckets: list(map()),
+          interval: integer(),
           doc_count_error_upper_bound: integer(),
           sum_other_doc_count: integer(),
           value: integer(),

--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -6,30 +6,30 @@ defmodule Snap.Aggregation do
   """
   defstruct ~w[
     buckets
-    interval
+    doc_count
     doc_count_error_upper_bound
+    interval
     sum_other_doc_count
     value
-    doc_count
   ]a
 
   def new(response) do
     %__MODULE__{
       buckets: response["buckets"],
-      interval: response["interval"],
+      doc_count: response["doc_count"],
       doc_count_error_upper_bound: response["doc_count_error_upper_bound"],
+      interval: response["interval"],
       sum_other_doc_count: response["sum_other_doc_count"],
       value: response["value"],
-      doc_count: response["doc_count"]
     }
   end
 
   @type t :: %__MODULE__{
           buckets: list(map()),
-          interval: integer(),
+          doc_count: integer(),
           doc_count_error_upper_bound: integer(),
+          interval: integer(),
           sum_other_doc_count: integer(),
           value: integer(),
-          doc_count: integer()
         }
 end

--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -6,6 +6,7 @@ defmodule Snap.Aggregation do
   """
   defstruct ~w[
     buckets
+    interval
     doc_count_error_upper_bound
     sum_other_doc_count
     value

--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -8,19 +8,25 @@ defmodule Snap.Aggregation do
     buckets
     doc_count_error_upper_bound
     sum_other_doc_count
+    value
+    doc_count
   ]a
 
   def new(response) do
     %__MODULE__{
       buckets: response["buckets"],
       doc_count_error_upper_bound: response["doc_count_error_upper_bound"],
-      sum_other_doc_count: response["sum_other_doc_count"]
+      sum_other_doc_count: response["sum_other_doc_count"],
+      value: response["value"],
+      doc_count: response["doc_count"]
     }
   end
 
   @type t :: %__MODULE__{
           buckets: list(map()),
           doc_count_error_upper_bound: integer(),
-          sum_other_doc_count: integer()
+          sum_other_doc_count: integer(),
+          value: integer(),
+          doc_count: integer()
         }
 end

--- a/test/fixtures/search_response_agg.json
+++ b/test/fixtures/search_response_agg.json
@@ -15,6 +15,12 @@
       ],
       "doc_count_error_upper_bound": 0,
       "sum_other_doc_count": 0
+    },
+    "people": {
+      "value": 8
+    },
+    "things": {
+      "doc_count": 9
     }
   },
   "hits": {

--- a/test/fixtures/search_response_agg.json
+++ b/test/fixtures/search_response_agg.json
@@ -21,6 +21,16 @@
     },
     "things": {
       "doc_count": 9
+    },
+    "histogram": {
+      "buckets": [
+        {
+          "doc_count": 10,
+          "key": 1647118800000,
+          "key_as_string": "2022-03-12T21:00:00.000Z"
+        }
+      ],
+      "interval": "30m"
     }
   },
   "hits": {

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -50,7 +50,7 @@ defmodule Snap.SearchResponseTest do
       |> Jason.decode!()
 
     response = SearchResponse.new(json)
-    assert Enum.count(response.aggregations) == 3
+    assert Enum.count(response.aggregations) == 4
 
     assert response.aggregations["season_values"] == %Snap.Aggregation{
              buckets: [%{"doc_count" => 69406, "key" => "summer"}],
@@ -64,6 +64,17 @@ defmodule Snap.SearchResponseTest do
 
     assert response.aggregations["things"] == %Snap.Aggregation{
              doc_count: 9
+           }
+
+    assert response.aggregations["histogram"] == %Snap.Aggregation{
+             buckets: [
+               %{
+                 "doc_count" => 10,
+                 "key_as_string" => "2022-03-12T21:00:00.000Z",
+                 "key" => 1_647_118_800_000
+               }
+             ],
+             interval: "30m"
            }
   end
 end

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -50,12 +50,20 @@ defmodule Snap.SearchResponseTest do
       |> Jason.decode!()
 
     response = SearchResponse.new(json)
-    assert Enum.count(response.aggregations) == 1
+    assert Enum.count(response.aggregations) == 3
 
     assert response.aggregations["season_values"] == %Snap.Aggregation{
              buckets: [%{"doc_count" => 69406, "key" => "summer"}],
              doc_count_error_upper_bound: 0,
              sum_other_doc_count: 0
+           }
+
+    assert response.aggregations["people"] == %Snap.Aggregation{
+             value: 8
+           }
+
+    assert response.aggregations["things"] == %Snap.Aggregation{
+             doc_count: 9
            }
   end
 end


### PR DESCRIPTION
# Why?

We've needed to support additional aggregation types to support our aggregation queries.

## What?

This PR introduces a few extra attributes on the `Snap.Aggregation` struct, specifically:

```elixir
%Snap.Aggregation{
  interval: integer(),
  value: integer(),
  doc_count: integer()
}
```

It also adds/updates tests for the additional attributes on the struct.

